### PR TITLE
Fix edn parsing of errors

### DIFF
--- a/src/pod/babashka/etaoin.clj
+++ b/src/pod/babashka/etaoin.clj
@@ -157,6 +157,15 @@
 
 (debug describe-map)
 
+; The ex-data may have [:driver :process] (a java.lang.Process)
+; or [:predicate] (a clojure.lang.AFunction), either of which render as #object
+; which will break when the other end tries to read it.
+; In case there is anything else just fix the representation of anything without
+; its own print-method.
+(defmethod print-method Object [v ^java.io.Writer w]
+  (.write w (pr-str {:type (type v)
+                     :str  (str v)})))
+
 (defn -main [& _args]
   (loop []
     (let [message (try (read)

--- a/src/pod/babashka/etaoin.clj
+++ b/src/pod/babashka/etaoin.clj
@@ -198,9 +198,16 @@
                           (catch Throwable e
                             (debug e)
                             (let [reply {"ex-message" (ex-message e)
-                                         "ex-data" (pr-str
-                                                    (assoc (ex-data e)
-                                                           :type (class e)))
+                                         "ex-data" (-> e
+                                                       (ex-data)
+                                                       ; Rename :type to preserve it
+                                                       ; so we can use :type for class.
+                                                       (as-> data
+                                                             (assoc data
+                                                                    :etaoin/type
+                                                                    (:type data)))
+                                                       (assoc :type (class e))
+                                                       pr-str)
                                          "id" id
                                          "status" ["done" "error"]}]
                               (write reply))))

--- a/test/pod/babashka/etaoin_test.clj
+++ b/test/pod/babashka/etaoin_test.clj
@@ -62,4 +62,15 @@
     (is (= driver
            (eta/wait-invisible driver :should-not-be-found)))
 
+    (is (= {:type 'clojure.lang.ExceptionInfo
+            :etaoin/type :etaoin/timeout}
+           (-> (try
+                 (eta/wait-visible driver :should-not-be-found {:timeout 1})
+                 nil
+                 (catch Throwable x
+                   x))
+               (ex-data)
+               (select-keys [:etaoin/type :type])))
+        "etaoin type preserved in ex-data")
+
     (eta/quit driver)))


### PR DESCRIPTION
When etaoin errors the ex-data includes objects that can't be read by the edn parser on the other side.