### PR TITLE
setup Windows/deps build to mirror lein build (#7)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,7 @@ build_script:
 
     powershell -Command "if (Test-Path('graalvm')) { return } else { Expand-Archive graalvm.zip graalvm }"
 
-    powershell -Command "if (Test-Path('bb.exe')) { return } else { (New-Object Net.WebClient).DownloadFile('https://github.com/borkdude/babashka/releases/download/v0.2.5/babashka-0.2.5-windows-amd64.zip', 'bb.zip') }"
+    powershell -Command "if (Test-Path('bb.exe')) { return } else { (New-Object Net.WebClient).DownloadFile('https://github.com/borkdude/babashka/releases/download/v0.5.0/babashka-0.5.0-windows-amd64.zip', 'bb.zip') }"
 
     powershell -Command "if (Test-Path('bb.exe')) { return } else { Expand-Archive bb.zip . }"
 

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,41 @@
+{:tasks
+ {:requires ([babashka.fs :as fs]
+             [clojure.string :as str])
+  :init     (def windows? (str/starts-with? (System/getProperty "os.name")
+                            "Windows"))
+  uberjar {:doc "Builds uberjar"
+           :task (when (seq (fs/modified-since "pod-babashka-etaoin.jar" "src"))
+                   (clojure "-X:uberjar"))}
+  graalvm {:doc "Checks GRAALVM_HOME env var"
+           :task
+                (let [env (System/getenv "GRAALVM_HOME")]
+                  (assert env "Set GRAALVM_HOME")
+                  env)}
+  native-image {:doc "Builds native image"
+                :depends [graalvm uberjar]
+                :task (do
+                        (shell (str (fs/file graalvm
+                                      "bin"
+                                      (if windows?
+                                        "gu.cmd"
+                                        "gu")))
+                          "install" "native-image")
+                        (shell (str (fs/file graalvm
+                                      "bin"
+                                      (if windows?
+                                        "native-image.cmd"
+                                        "native-image")))
+                          "-cp" "pod-babashka-etaoin.jar"
+                          "-H:Name=pod-babashka-etaoin"
+                          "-H:+ReportExceptionStackTraces"
+                          "--initialize-at-build-time"
+                          "-H:EnableURLProtocols=jar"
+                          "--report-unsupported-elements-at-runtime"
+                          "-H:EnableURLProtocols=http,https,jar"
+                          "--enable-all-security-services"
+                          "-H:ReflectionConfigurationFiles=reflection.json"
+                          "--verbose"
+                          "--no-fallback"
+                          "--no-server"
+                          "-J-Xmx3g"
+                          "pod.babashka.etaoin"))}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:deps {etaoin {:mvn/version "0.3.6"}
+{:deps {borkdude/etaoin-graal {:mvn/version "0.4.2-deb92aaa21c59c52521f42c0177bbce9ac10a0e2"}
         nrepl/bencode {:mvn/version "1.1.0"}}
  :aliases
  {:test
@@ -10,4 +10,13 @@
     {:git/url "https://github.com/babashka/babashka.pods"
      :sha "feb48af75f60a4e31bfb434eb7321fd93c4a31cb"}}
    :extra-paths ["test"]
-   :main-opts ["-m" "cognitect.test-runner"]}}}
+   :main-opts ["-m" "cognitect.test-runner"]}
+  :uberjar
+  {:replace-deps
+              {com.github.seancorfield/depstar {:mvn/version "2.0.216"}}
+   :exec-fn hf.depstar/uberjar
+   :exec-args {:jar pod-babashka-etaoin.jar
+               :main-class pod.babashka.etaoin
+               :aot true
+               :jvm-opts ["-Dclojure.compiler.direct-linking=true"
+                          "-Dclojure.spec.skip-macros=true"]}}}}

--- a/script/compile.bat
+++ b/script/compile.bat
@@ -8,7 +8,7 @@ if "%GRAALVM_HOME%"=="" (
 set JAVA_HOME=%GRAALVM_HOME%
 set PATH=%GRAALVM_HOME%\bin;%PATH%
 
-set /P VERSION=< resources\POD_BABASHKA_ETAOIN_VERSION
+set /P VERSION=< resources\POD_VERSION
 echo Building version %VERSION%
 
 if "%GRAALVM_HOME%"=="" (
@@ -16,26 +16,7 @@ echo Please set GRAALVM_HOME
 exit /b
 )
 
-bb --clojure -X:native:uberjar
-
-call %GRAALVM_HOME%\bin\gu.cmd install native-image
-
-call %GRAALVM_HOME%\bin\native-image.cmd ^
-  "-cp" "pod-babashka-etaoin.jar" ^
-  "-H:Name=pod-babashka-etaoin" ^
-  "-H:+ReportExceptionStackTraces" ^
-  "--initialize-at-build-time" ^
-  "-H:EnableURLProtocols=jar" ^
-  "--report-unsupported-elements-at-runtime" ^
-  "-H:EnableURLProtocols=http,https,jar" ^
-  "--enable-all-security-services" ^
-  "-H:ReflectionConfigurationFiles=reflection.json" ^
-  "-H:ResourceConfigurationFiles=resources.json" ^
-  "--verbose" ^
-  "--no-fallback" ^
-  "--no-server" ^
-  "-J-Xmx3g" ^
-  "pod.babashka.etaoin"
+bb run native-image
 
 if %errorlevel% neq 0 exit /b %errorlevel%
 


### PR DESCRIPTION
- add uberjar alias to deps.edn
- add bb.edn with tasks for building native image
- call bb task from compile script

I'm hoping I got this right the way you were looking for it (using bb tasks with `clojure -X:uberjar`). I didn't touch the linux build (yet), but I'm hoping this will get to a working Windows build. I'm pretty sure the only thing I couldn't find a way to do with depstar that's in the lein build is setting `*assert*` to false.

There may be a little tweak needed somewhere, because the test file doesn't immediately work on Windows - I needed to turn the `keys/enter` character into a string in the argument to `fill` in `example.clj`. But I don't think that's a huge deal, and I can't find any correlation between the build process and that issue (building the linux binary using the bb task yields a working executable).